### PR TITLE
Adjust profile image size

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body class="bg-gray-100">
     <div class="max-w-4xl mx-auto px-4 py-8">
         <header class="text-center mb-12">
-            <img src="assets/about_me.jpg" alt="Andres Sandoval" class="w-48 h-48 object-cover rounded-full mx-auto mb-4 shadow-lg">
+            <img src="assets/about_me.jpg" alt="Andres Sandoval" class="w-32 h-32 object-cover rounded-full mx-auto mb-4 shadow-lg">
             <h1 class="text-4xl font-bold text-gray-800 mb-2">Andres Sandoval</h1>
             <p class="text-xl text-gray-600">Android Software Engineer</p>
             <div class="mt-4 mb-4">


### PR DESCRIPTION
This PR reduces the profile image size to make it more proportional to the page layout.

Changes:
- Changed image size from w-48 h-48 (192px) to w-32 h-32 (128px)
- Maintains circular shape and shadow effects
- Keeps the object-cover property for proper image scaling

The smaller size will create a better visual balance with the rest of the content.